### PR TITLE
Remove duplicated contract in Faucet.sol

### DIFF
--- a/contracts/utils/Faucet.sol
+++ b/contracts/utils/Faucet.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.13;
 
 import "solmate/tokens/ERC20.sol";
+import {RescueFundsLib} from "../libraries/RescueFundsLib.sol";
 
 /// @notice Safe ETH and ERC20 transfer library that gracefully handles missing return values.
 /// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/SafeTransferLib.sol)
@@ -150,45 +151,6 @@ library SafeTransferLib {
 }
 
 error ZeroAddress();
-
-/**
- * @title RescueFundsLib
- * @dev A library that provides a function to rescue funds from a contract.
- */
-
-library RescueFundsLib {
-    /**
-     * @dev The address used to identify ETH.
-     */
-    address public constant ETH_ADDRESS =
-        address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
-
-    /**
-     * @dev thrown when the given token address don't have any code
-     */
-    error InvalidTokenAddress();
-
-    /**
-     * @dev Rescues funds from a contract.
-     * @param token_ The address of the token contract.
-     * @param rescueTo_ The address of the user.
-     * @param amount_ The amount of tokens to be rescued.
-     */
-    function rescueFunds(
-        address token_,
-        address rescueTo_,
-        uint256 amount_
-    ) internal {
-        if (rescueTo_ == address(0)) revert ZeroAddress();
-
-        if (token_ == ETH_ADDRESS) {
-            SafeTransferLib.safeTransferETH(rescueTo_, amount_);
-        } else {
-            if (token_.code.length == 0) revert InvalidTokenAddress();
-            SafeTransferLib.safeTransfer(ERC20(token_), rescueTo_, amount_);
-        }
-    }
-}
 
 /**
  * @title Ownable


### PR DESCRIPTION
On `yarn setup:all`, I found an issue where there is a duplicated abi
`Error in plugin hardhat-abi-exporter: multiple distinct contracts share same output destination: /home/rookmate/socket/socket-plugs/artifacts/abi/RescueFundsLib.json`

There is one contract in `libraries/RescueFundsLib` and a copy inside `utils/Faucet.sol`. I assume the Faucet should not be duplicating it.