### PR TITLE
Change overrides variable to expect a number instead of "in ChainSlug"

### DIFF
--- a/script/helpers/networks.ts
+++ b/script/helpers/networks.ts
@@ -21,7 +21,7 @@ export const gasPrice = undefined;
 export const type = 2;
 
 export const overrides: {
-  [chain in ChainSlug]?: Overrides;
+  [chain: number]: Overrides;
 } = {
   [ChainSlug.ARBITRUM_SEPOLIA]: {
     type,


### PR DESCRIPTION
As discussed with @tHeMaskedMan981 the goal with this change is to allow custom networks to be added without having to edit `node_modules/@socket.tech/dl-core/dist/src/enums/chainSlug.d.ts` or to have a new `dl-core` version for every new chain.

This way overriding information for a new chain can be done. Example for Polygon Amoy :
```
export const overrides: {
  [chain: number]: Overrides;
} = {
  [80002]: {
    type: 0,
    gasLimit: 20_000_000
  },
...
}
```
If an integrator needs to confirm what is the expected chain ID he can also check the file `script/constants/projectConstants/super<bridge/token>/<project_name>_testnet.ts`
